### PR TITLE
feat: Add security group id to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ module "ecs_app" {
 | <a name="module_alb_ingress"></a> [alb\_ingress](#module\_alb\_ingress) | cloudposse/alb-ingress/aws | 0.25.1 |
 | <a name="module_autoscaling"></a> [autoscaling](#module\_autoscaling) | cloudposse/ecs-cloudwatch-autoscaling/aws | 0.7.3 |
 | <a name="module_ecs_alarms"></a> [ecs\_alarms](#module\_ecs\_alarms) | cloudposse/ecs-cloudwatch-sns-alarms/aws | 0.12.3 |
+| <a name="module_ecs_service_sg"></a> [ecs\_service\_sg](#module\_ecs\_service\_sg) | cloudposse/security-group/aws | 2.2.0 |
 | <a name="module_service"></a> [service](#module\_service) | cloudposse/ecs-alb-service-task/aws | 0.58.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 ## Resources
@@ -107,7 +108,6 @@ module "ecs_app" {
 |------|------|
 | [aws_cloudwatch_log_group.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_lb_listener.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_security_group.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.opened_to_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_lb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
 ## Inputs
@@ -223,6 +223,7 @@ module "ecs_app" {
 | Name | Description |
 |------|-------------|
 | <a name="output_alb_listener_arns"></a> [alb\_listener\_arns](#output\_alb\_listener\_arns) | The ARN of the ALB listeners. |
+| <a name="output_ecs_service_security_group_id"></a> [ecs\_service\_security\_group\_id](#output\_ecs\_service\_security\_group\_id) | n/a |
 | <a name="output_service_arn"></a> [service\_arn](#output\_service\_arn) | ECS Service ARN |
 | <a name="output_service_name"></a> [service\_name](#output\_service\_name) | ECS Service name |
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | ECS task definition family |

--- a/main.tf
+++ b/main.tf
@@ -89,9 +89,10 @@ resource "aws_lb_listener" "app" {
 }
 
 module "ecs_service_sg" {
-  count   = local.enabled ? 1 : 0
   source  = "cloudposse/security-group/aws"
   version = "2.2.0"
+
+  enabled = local.enabled
 
   name                       = local.ecs_service_task_sg_name
   security_group_description = "ECS service task SG for ${module.this.id}"
@@ -142,7 +143,7 @@ module "service" {
   launch_type                        = var.service_launch_type
   vpc_id                             = var.vpc_id
   security_group_enabled             = var.default_service_security_group_enabled
-  security_groups                    = concat(module.ecs_service_sg.*.id, var.service_security_groups)
+  security_groups                    = concat([module.ecs_service_sg.id], var.service_security_groups)
   subnet_ids                         = var.subnet_ids
   ignore_changes_task_definition     = var.service_ignore_changes_task_definition
   ignore_changes_desired_count       = var.service_ignore_changes_desired_count

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,7 @@ output "alb_listener_arns" {
   description = "The ARN of the ALB listeners."
   value       = aws_lb_listener.app.*.arn
 }
+
+output "ecs_service_security_group_id" {
+  value = module.ecs_service_sg.id
+}


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

Add the security group ids to the output of the module.

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?

The security group id is not present in the output of the module.

## What is the new behavior?

The security group id is present in the output of the module.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a

