### PR TITLE
docs: Add the missing description for the new  output

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ module "ecs_app" {
 | Name | Description |
 |------|-------------|
 | <a name="output_alb_listener_arns"></a> [alb\_listener\_arns](#output\_alb\_listener\_arns) | The ARN of the ALB listeners. |
-| <a name="output_ecs_service_security_group_id"></a> [ecs\_service\_security\_group\_id](#output\_ecs\_service\_security\_group\_id) | n/a |
+| <a name="output_ecs_service_security_group_id"></a> [ecs\_service\_security\_group\_id](#output\_ecs\_service\_security\_group\_id) | The ID of the Security Group for the ECS service. |
 | <a name="output_service_arn"></a> [service\_arn](#output\_service\_arn) | ECS Service ARN |
 | <a name="output_service_name"></a> [service\_name](#output\_service\_name) | ECS Service name |
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | ECS task definition family |

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,5 +24,6 @@ output "alb_listener_arns" {
 }
 
 output "ecs_service_security_group_id" {
-  value = module.ecs_service_sg.id
+  description = "The ID of the Security Group for the ECS service."
+  value       = module.ecs_service_sg.id
 }


### PR DESCRIPTION
GitHub Issue:  n/a

## Proposed Changes

Add the new output description.

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [x] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?

The `ecs_service_security_group_id` output description is missing from the docs.


## What is the new behavior?
The `ecs_service_security_group_id` output description is added to the docs.


## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a
