### PR TITLE
feat: add ECS task role and exec role ARNs to the output of the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ module "ecs_app" {
 | <a name="output_service_arn"></a> [service\_arn](#output\_service\_arn) | ECS Service ARN |
 | <a name="output_service_name"></a> [service\_name](#output\_service\_name) | ECS Service name |
 | <a name="output_task_definition_family"></a> [task\_definition\_family](#output\_task\_definition\_family) | ECS task definition family |
+| <a name="output_task_exec_role_arn"></a> [task\_exec\_role\_arn](#output\_task\_exec\_role\_arn) | ECS Task exec role ARN |
+| <a name="output_task_role_arn"></a> [task\_role\_arn](#output\_task\_role\_arn) | ECS Task role ARN |
 | <a name="output_url"></a> [url](#output\_url) | Full URL of the app |
 ## Breaking Changes
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,13 @@ output "ecs_service_security_group_id" {
   description = "The ID of the Security Group for the ECS service."
   value       = module.ecs_service_sg.id
 }
+
+output "task_exec_role_arn" {
+  value       = module.service.task_exec_role_arn
+  description = "ECS Task exec role ARN"
+}
+
+output "task_role_arn" {
+  value       = module.service.task_role_arn
+  description = "ECS Task role ARN"
+}


### PR DESCRIPTION
## Proposed Changes
Add ECS task role and exec role ARNs to the output of the module

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?
ECS task role and exec role ARNs are not present in the output of the module.


## What is the new behavior?
ECS task role and exec role ARNs are present in the output of the module.


## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [x] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [x] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).


