### PR TITLE
fix: pass the value of variable health_check_unhealthy_threshold

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,21 +30,22 @@ module "alb_ingress" {
   source  = "cloudposse/alb-ingress/aws"
   version = "0.25.1"
 
-  vpc_id                         = var.vpc_id
-  port                           = var.service_container_port
-  protocol                       = var.service_container_protocol
-  health_check_enabled           = var.health_check_enabled
-  health_check_path              = local.health_check_path
-  health_check_matcher           = var.health_check_matcher
-  health_check_port              = var.health_check_port
-  health_check_protocol          = var.health_check_protocol
-  health_check_timeout           = var.health_check_timeout
-  health_check_healthy_threshold = var.health_check_healthy_threshold
-  health_check_interval          = var.health_check_interval
-  default_target_group_enabled   = true
-  stickiness_type                = var.alb_ingress_stickiness_type
-  stickiness_cookie_duration     = var.alb_ingress_stickiness_cookie_duration
-  stickiness_enabled             = var.alb_ingress_stickiness_enabled
+  vpc_id                           = var.vpc_id
+  port                             = var.service_container_port
+  protocol                         = var.service_container_protocol
+  health_check_enabled             = var.health_check_enabled
+  health_check_path                = local.health_check_path
+  health_check_matcher             = var.health_check_matcher
+  health_check_port                = var.health_check_port
+  health_check_protocol            = var.health_check_protocol
+  health_check_timeout             = var.health_check_timeout
+  health_check_healthy_threshold   = var.health_check_healthy_threshold
+  health_check_unhealthy_threshold = var.health_check_unhealthy_threshold
+  health_check_interval            = var.health_check_interval
+  default_target_group_enabled     = true
+  stickiness_type                  = var.alb_ingress_stickiness_type
+  stickiness_cookie_duration       = var.alb_ingress_stickiness_cookie_duration
+  stickiness_enabled               = var.alb_ingress_stickiness_enabled
 
   context    = module.this.context
   attributes = concat(module.this.attributes, [lower(var.service_container_protocol), var.service_container_port])


### PR DESCRIPTION
fix: pass the value of variable health_check_unhealthy_threshold to the alb_ingress module

## Proposed Changes

 - [X] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
The value of the variable health_check_unhealthy_threshold is not passed and assigned in the module.

## What is the new behavior?
This fixes the issue.

## Checklist

Please check that your PR fulfills the following requirements:

- [X] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [X] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information
Sup juju ಥ‿ಥ
